### PR TITLE
Returning 404 for category/uncategorized

### DIFF
--- a/pages/category/uncategorized.jsx
+++ b/pages/category/uncategorized.jsx
@@ -1,0 +1,12 @@
+// Should take precedence over [slug].jsx
+import PageWrapper from "../../layouts/PageWrapper";
+import React, { Component } from "react";
+import Error from "next/error";
+
+class Uncategorized extends Component {
+  render() {
+    return <Error statusCode={404} />;
+  }
+}
+
+export default PageWrapper(Uncategorized);


### PR DESCRIPTION
Previous attempt supposedly didn't work because category/[slug].jsx is hard to change. Instead this tries to prevent [slug].jsx running by creating an uncategorized file that just returns Error 404 page.