### PR TITLE
Changed order of Footer Links

### DIFF
--- a/components/MainSiteFooter/index.jsx
+++ b/components/MainSiteFooter/index.jsx
@@ -8,14 +8,14 @@ export default function MainSiteFooter(props) {
   const mainSiteFooterLinks = [
     { text: "About", url: "/about" },
     { text: "Contact", url: "/contact" },
+    { text: "Submit", url: "/submit" },
     { text: "Advertise", url: "/advertise" },
     { text: "Staff", url: "/staff" },
     { text: "Stonewall", url: "/stonewall" },
     { text: "Editorial Board", url: "/editorial-board" },
     { text: "Privacy", url: "/privacy" },
     { text: "Comment Policy", url: "/comment" },
-    { text: "Community Guide", url: "/the-daily-bruin-community-guide" },
-    { text: "Submit", url: "/submit" }
+    { text: "Community Guide", url: "/the-daily-bruin-community-guide" }
   ];
 
   const renderedLinks = mainSiteFooterLinks.map(link => (


### PR DESCRIPTION
Was originally "About Contact Advertise Staff Stonewall 'Editorial Board' Privacy 'Comment Policy' 'Community Guide' Submit"

Is Now "About Contact Submit Advertise Staff Stonewall 'Editorial Board' Privacy 'Comment Policy' 'Community Guide'"