### PR TITLE
Added ACTIONS_ALLOW_USE_UNSECURED_NODE_VERSION

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,3 +27,4 @@ jobs:
       - run: pm2 reload flamingo # reloads on the DigitalOcean droplet
         env:
           CI: true
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true


### PR DESCRIPTION
github actions no longer support the use of node v12 unless this flag is used (hopefully). Otherwise the entire system will have to be updated to node v16.