### PR TITLE
fixed tablet-size error

### DIFF
--- a/layouts/Article/index.jsx
+++ b/layouts/Article/index.jsx
@@ -119,7 +119,7 @@ function ArticleLayout({article, authors, relatedPosts, classifieds})
                       width: "100%"
                     }}
                   >
-                    <div className={css.card}>{article}</div>
+                    <div className={css.card}>{articleBuild}</div>
                     <div className={css.card}>
                       <CommentsCard
                         id={article.id}


### PR DESCRIPTION
when the website was shrunk to tablet size, it would not work.

this is because the website was trying to render an object, rather than a React element.