### PR TITLE
Added filter to landing page

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -148,6 +148,29 @@ class Index extends Component {
     posts.hStory = await hStoryRes.json();
     const classifieds = await classifiedsRes.json();
     const sponsored = await sponsoredRes.text();
+
+    // Filter to necessary keys (reduces data sent to user's browser)
+    for (let [key, value] of Object.entries(posts)) {
+      
+      for (var i=0; i<value.length; i++)
+      {
+        value[i] = {
+          id: value[i].id,
+          date: value[i].date,
+          link: value[i].link,
+          slug: value[i].slug,
+          title: value[i].title,
+          coauthors: value[i].coauthors,
+          categories: value[i].categories,
+          excerpt: value[i].excerpt,
+          _links: value[i]._links,
+          tags: value[i].tags,
+          acf: value[i].acf,
+          _embedded: value[i]._embedded
+        };
+      }
+    }
+
     return { posts, multimediaPosts, classifieds, sponsored };
   }
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -149,7 +149,7 @@ class Index extends Component {
     const classifieds = await classifiedsRes.json();
     const sponsored = await sponsoredRes.text();
 
-    // Filter to necessary keys (reduces data sent to user's browser)
+    // Filter posts necessary keys (reduces data sent to user's browser)
     for (let [key, value] of Object.entries(posts)) {
       
       for (var i=0; i<value.length; i++)
@@ -168,6 +168,17 @@ class Index extends Component {
           acf: value[i].acf,
           _embedded: value[i]._embedded
         };
+      }
+    }
+
+    // Filter multimediaPosts to necessary keys
+    // Assumes that this is a 1D array of multimediaPosts
+    for (var i=0; i<multimediaPosts.length; i++) {
+      multimediaPosts[i] = {
+        id: multimediaPosts[i].id,
+        title: multimediaPosts[i].title,
+        link: multimediaPosts[i].link,
+        _embedded: multimediaPosts[i]._embedded,
       }
     }
 


### PR DESCRIPTION
Added only necessary keys when posts are coming in to the landing page.
Replicates the effect of adding _fields=... component to the WordPress fetch calls, except this doesn't return stale data (filters after the full fetch).