### PR TITLE
Fixed category linking in StoryList

### DIFF
--- a/components/StoryList/index.jsx
+++ b/components/StoryList/index.jsx
@@ -51,7 +51,7 @@ class StoryList extends React.Component {
             </a>
             <span>
           <a
-            href={this.props.story[0].link} // this is going to be broken
+            href={this.props.category.as}
             css={css`
               text-decoration: none;
               color: ${globals.DBblue};

--- a/layouts/utilities.jsx
+++ b/layouts/utilities.jsx
@@ -81,7 +81,9 @@ export function buildStoryList(type, list, link) {
         alt: "N/A"
       }}
       category={{
-        name: list[0]._embedded["wp:term"][0][0].name
+        name: list[0]._embedded["wp:term"][0][0].name,
+        href: `/category/[slug]`,
+        as: `/category/${list[0]._embedded["wp:term"][0][0].slug}`
       }}
       date={list[0].date}
     />


### PR DESCRIPTION
- Previously, on the StoryList component, the category link just linked to the article (e.g. "A Closer Look", "Baseball", etc)
- Passed in correct link to props of StoryList, now correctly linking