### PR TITLE
Fix mobile subcategories

### DIFF
--- a/components/SectionHeader/index.jsx
+++ b/components/SectionHeader/index.jsx
@@ -238,7 +238,11 @@ export default class SectionHeader extends React.Component {
                 }
                 `}
               @media (max-width: 600px) {
-                display: none;
+                text-align: center;
+                a { 
+                  display: block;
+                  margin: 4px 0;
+                } 
               }
             `}
           >

--- a/components/SectionHeader/index.jsx
+++ b/components/SectionHeader/index.jsx
@@ -240,8 +240,9 @@ export default class SectionHeader extends React.Component {
               @media (max-width: 600px) {
                 text-align: center;
                 a { 
-                  display: block;
-                  margin: 4px 0;
+                  display: inline-block;
+                  margin: 4px 8px;
+                  white-space: normal;
                 } 
               }
             `}

--- a/pages/category/games/index.jsx
+++ b/pages/category/games/index.jsx
@@ -6,7 +6,6 @@ import SectionHeader from "../../../components/SectionHeader";
 import WestwordleLogo from "../../../components/GamesCard/WestWordLogoCropped.png"; 
 import WhackaBruinLogo from "../../../components/GamesCard/WhackABruinLogo.png"; 
 import PhotoCard from "../../../components/PhotoCard"; 
-// import * as utilities from "../../../components/PhotoCard/utilities";
 
 const GamesIndex = () => {
   return (
@@ -26,6 +25,7 @@ const GamesIndex = () => {
           as="/category/games/westwordle"
           link="/category/games/westwordle"
           image={WestwordleLogo} 
+
           excerpt="Guess the Daily Bruin-themed word in 6 tries."
           authors={[{ "display_name": "Daily Bruin Games Team" }]}
         />
@@ -37,11 +37,13 @@ const GamesIndex = () => {
           link="/category/games/whack-a-bruin"
           image={WhackaBruinLogo} 
           excerpt="Whack the Bruins and beat your high score!"
+
           authors={[
             { "display_name": "Johnny Zheng", "user_nicename": "JohnnyZheng" },
             { "display_name": "Hillary Nguyen", "user_nicename": "HNguyen" },
             { "display_name": "Aileen Chen", "user_nicename": "AChen" }
           ]}
+
         />
       </div>
     </>


### PR DESCRIPTION
This removes a CSS rule that hid subcategories on screens under 600px. They now appear as a stacked list on mobile.