### PR TITLE
extract wordpress api fetching into shared lib functions

### DIFF
--- a/layouts/Category/index.jsx
+++ b/layouts/Category/index.jsx
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import Error from "next/error";
-import { Config } from "../../config.js";
 import css from "../style.module.css";
+
+import { fetchPostsFromCategoryIdPaginated } from "../../lib/fetchWordPress";
 import * as utilities from "../utilities";
 import InfiniteScroll from "react-infinite-scroller";
 import Media from "react-media";
@@ -24,35 +25,19 @@ export default class CategoryLayout extends React.Component {
   }
 
   getPosts(page) {
-    fetch(
-      `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&categories=${this.props.categoryID}&page=${page}`
-    )
-      .then(response => response.json())
-      .then(
-        json => {
-          if (json.data == undefined && json.length != 0) {
-            this.setState({
-              otherArticleCards: this.state.otherArticleCards.concat(
-                utilities.buildArticleList(json)
-              )
-            });
-          } else {
-            this.setState({
-              more: false
-            });
-          }
-        },
-        error => {
+    fetchPostsFromCategoryIdPaginated(this.props.categoryID, page)
+      .then(posts => {
+        if (posts && posts.length > 0) {
           this.setState({
-            more: false
+            otherArticleCards: this.state.otherArticleCards.concat(
+              utilities.buildArticleList(posts)
+            )
           });
+        } else {
+          this.setState({ more: false });
         }
-      )
-      .catch(err =>
-        this.setState({
-          more: false
-        })
-      );
+      })
+      .catch(() => this.setState({ more: false }));
   }
 
   // TODO: DO NOT HARDOCODE THIS. MAKE SIDEBAR CUSTOMIZABLE.

--- a/layouts/PageWrapper.jsx
+++ b/layouts/PageWrapper.jsx
@@ -1,6 +1,7 @@
 import React, { Component, useEffect } from "react";
-import { Config } from "../config.js";
 import Head from "next/head";
+
+import { fetchSharedData } from "../lib/fetchData";
 import Media from "react-media";
 
 import MainSiteFooter from "components/MainSiteFooter";
@@ -26,56 +27,13 @@ const layoutStyle = {
 const PageWrapper = (Comp, wrapperProps = {}) =>
   class PageWrapperInternal extends Component {
     static async getInitialProps(ctx) {
-      // Load the categories for the header
-      // TODO: can we load this once each browser session?
-      // only call getInitialProps if the child has that function
-      const [childProps, categoriesRes] = await Promise.all([
+      const [childProps, sharedData] = await Promise.all([
         Comp.getInitialProps ? Comp.getInitialProps(ctx) : null,
-        fetch(`${Config.apiUrl}/wp-json/wp/v2/categories`)
+        fetchSharedData()
       ]);
-
-      // Masthead Headers
-      const mastheadCategoriesRes = await fetch(
-        `${Config.apiUrl}/wp-json/menus/v1/menus/masthead`
-      );
-      const categories = await mastheadCategoriesRes.json();
-      let mappedCategories = null;
-      if (categories.items.length != 0) {
-        mappedCategories = categories.items.map(index => {
-          return { name: index.title, href: index.url, as: index.url };
-        });
-      }
-      mappedCategories.splice(15, 0, {name: "Games", href: "/category/games", as: "/category/games"})
-
-      // BreakingCard
-      const breakingRes = await fetch(
-        `${Config.apiUrl}/wp-json/menus/v1/menus/breaking`
-      );
-      const breaking = await breakingRes.json();
-      let mappedBreaking = null;
-      if (breaking.items.length != 0) {
-        mappedBreaking = {
-          name: breaking.items[0].title,
-          href: breaking.items[0].url
-        };
-      }
-
-      // InTheNews
-      const itnRes = await fetch(
-        `${Config.apiUrl}/wp-json/menus/v1/menus/in-the-news`
-      );
-      const itn = await itnRes.json();
-      let mappedITN = null;
-      if (itn.items.length != 0) {
-        mappedITN = itn.items.map(index => {
-          return { name: index.title, href: index.url, as: index.url };
-        });
-      }
       return {
         ...(Comp.getInitialProps ? childProps : null),
-        mappedCategories,
-        mappedBreaking,
-        mappedITN
+        ...sharedData
       };
     }
 

--- a/lib/fetchWordPress.js
+++ b/lib/fetchWordPress.js
@@ -1,0 +1,99 @@
+import { Config } from "../config";
+import { safeJsonArray, fetchWithTimeout } from "./fetchHelpers";
+
+/*
+ * Fetch a category by slug from the WordPress API.
+ * Returns array of category objects, or [] if not found/error.
+ */
+export async function fetchCategoryWithSlug(slug) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/categories?slug=${slug}`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch posts for a category ID.
+ * Returns array of posts (with _embed).
+ */
+export async function fetchPostsFromCategoryId(categoryId) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&categories=${categoryId}`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch posts for a category ID with pagination (for infinite scroll).
+ */
+export async function fetchPostsFromCategoryIdPaginated(categoryId, page = 1) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&categories=${categoryId}&page=${page}`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch subcategories (children) for a category ID.
+ * Returns array of category objects.
+ */
+export async function fetchSubcategoriesForCategoryId(categoryId) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/categories?parent=${categoryId}&per_page=100`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch featured classifieds.
+ * Used across category, tag, and author pages.
+ */
+export async function fetchClassifieds() {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/classifieds?_embed&Featured=3`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch a tag by slug from the WordPress API.
+ * Returns array of tag objects, or [] if not found/error.
+ */
+export async function fetchTagWithSlug(slug) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/tags?slug=${slug}`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch posts for a tag ID.
+ */
+export async function fetchPostsFromTagId(tagId) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&tags=${tagId}`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch an author/user by slug from the WordPress API.
+ * Returns array of user objects, or [] if not found/error.
+ */
+export async function fetchAuthorWithSlug(slug) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/users?slug=${slug}`
+  );
+  return safeJsonArray(res);
+}
+
+/*
+ * Fetch posts by author slug.
+ * categories_exclude removes breaking feed posts (27179, 27127).
+ */
+export async function fetchPostsFromAuthorSlug(slug) {
+  const res = await fetchWithTimeout(
+    `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&filter[author_name]=${slug}&categories_exclude=27179,27127`
+  );
+  return safeJsonArray(res);
+}

--- a/lib/fetchWordPress.js
+++ b/lib/fetchWordPress.js
@@ -90,10 +90,12 @@ export async function fetchAuthorWithSlug(slug) {
 /*
  * Fetch posts by author slug.
  * categories_exclude removes breaking feed posts (27179, 27127).
+ * Uses 20s timeout - author posts require scanning most of the WP database.
  */
 export async function fetchPostsFromAuthorSlug(slug) {
   const res = await fetchWithTimeout(
-    `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&filter[author_name]=${slug}&categories_exclude=27179,27127`
+    `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&filter[author_name]=${slug}&categories_exclude=27179,27127`,
+    20000
   );
   return safeJsonArray(res);
 }

--- a/pages/author/[slug].jsx
+++ b/pages/author/[slug].jsx
@@ -1,22 +1,28 @@
 import PageWrapper from "../../layouts/PageWrapper";
 import React, { Component } from "react";
 import Error from "next/error";
-import { Config } from "../../config.js";
 import Head from "next/head";
+
+import {
+  fetchAuthorWithSlug,
+  fetchPostsFromAuthorSlug,
+  fetchClassifieds
+} from "../../lib/fetchWordPress";
 
 import AuthorLayout from "../../layouts/Author";
 
 class Author extends Component {
   static async getInitialProps(context) {
     const { slug } = context.query;
-    const authorRes = await fetch(
-      `${Config.apiUrl}/wp-json/wp/v2/users?slug=${slug}`
-    );
-    const author = await authorRes.json();
-    const postsRes = await fetch(
-      `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&filter[author_name]=${slug}&categories_exclude=27179,27127` // 27179 is the category id of breaking feed posts
-    );
-    const postsRaw = await postsRes.json();
+    const [author, postsRaw, classifiedsRaw] = await Promise.all([
+      fetchAuthorWithSlug(slug),
+      fetchPostsFromAuthorSlug(slug),
+      fetchClassifieds()
+    ]);
+
+    if (author.length === 0) {
+      return { author: [] };
+    }
 
     // Trim posts to reduce page data size
     const posts = postsRaw.map(post => {
@@ -60,10 +66,6 @@ class Author extends Component {
       };
     });
 
-    const classifiedsRes = await fetch(
-      `${Config.apiUrl}/wp-json/wp/v2/classifieds?_embed&Featured=3`
-    );
-    const classifiedsRaw = await classifiedsRes.json();
     const classifieds = classifiedsRaw.map(c => ({
       category: {
         name: c._embedded["wp:term"][1][0].name,

--- a/pages/tag/[slug].jsx
+++ b/pages/tag/[slug].jsx
@@ -1,8 +1,13 @@
 import PageWrapper from "../../layouts/PageWrapper";
 import React from "react";
 import Error from "next/error";
-import { Config } from "../../config.js";
 import Head from "next/head";
+
+import {
+  fetchTagWithSlug,
+  fetchPostsFromTagId,
+  fetchClassifieds
+} from "../../lib/fetchWordPress";
 
 import TagHeader from "../../components/TagHeader";
 import TagLayout from "../../layouts/Tag";
@@ -46,19 +51,12 @@ function Tag({ tag, posts, classifieds }) {
 
 Tag.getInitialProps = async (context) => {
   const { slug } = context.query;
-  const tagRes = await fetch(
-    `${Config.apiUrl}/wp-json/wp/v2/tags?slug=${slug}`
-  );
-  const tag = await tagRes.json();
+  const tag = await fetchTagWithSlug(slug);
   if (tag.length > 0) {
-    const postsRes = await fetch(
-      `${Config.apiUrl}/wp-json/wp/v2/posts?_embed&tags=${tag[0].id}`
-    );
-    const posts = await postsRes.json();
-    const classifiedsRes = await fetch(
-      `${Config.apiUrl}/wp-json/wp/v2/classifieds?_embed&Featured=3`
-    );
-    const classifieds = await classifiedsRes.json();
+    const [posts, classifieds] = await Promise.all([
+      fetchPostsFromTagId(tag[0].id),
+      fetchClassifieds()
+    ]);
     return { tag, posts, classifieds };
   }
   return { tag };


### PR DESCRIPTION
moved common fetch logic out of pages and layouts into lib/fetchWordPress.js. category, tag, and author pages now use these helpers instead of inline fetch calls. PageWrapper uses fetchSharedData from fetchData.js. also switched everything over to fetchWithTimeout and safeJsonParse for consistency